### PR TITLE
changes based on today's retrospective meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@
 
 Anyone is free to propose new developments by writing an RFC (request for comment). Submit an RFC by copying and filling the template [rfc/0000-template.md](./rfc/0000-template.md). Create new file `rfc/xxxx-feature-name.md`. When you are ready for your feature to be reviewed, submit a pr.
 
+The team makes a final decidsion after the RFC has been discussed and the benefits and drawbacks are well understood. At that point the rfc is either
+- approved (merged)
+- rejected (pr is closed)
+- or postponed (pr tagged with the "postponed" label and closed)
+
 ## Spec
 
-An implementation spec is the next step after the RFC. Copy the template [spec/0000-template.md](./spec/0000-template.md) over to `spec/xxxx-feature-name.md` to get started. The spec can be submitted in the same PR as your RFC or it can be submitted separately.
+An implementation spec is the optional next step after the RFC. Copy the template [spec/0000-template.md](./spec/0000-template.md) over to `spec/xxxx-feature-name.md` to get started. The spec can be submitted in the same PR as your RFC or it can be submitted separately.
 
 ## Markdown Formatting
 

--- a/rfc/0000-template.md
+++ b/rfc/0000-template.md
@@ -8,6 +8,8 @@ Authors: *Name One, Name Two*
 
 ## Abstract
 
+*Do your best to use layman's terms in this section.*
+
 ## Suggested Reading
 
 *Bulleted list suggested.*


### PR DESCRIPTION
- be explicit about what a merge means
- remind rfc writers to use layman's terms for the section labeled "abstract"